### PR TITLE
Improve readability of workflows and corresponding stacks

### DIFF
--- a/ops.yml
+++ b/ops.yml
@@ -7,6 +7,7 @@ pipelines:
         - DEBIAN_FRONTEND=noninteractive
         - ORG=workflows-sh
         - REPO=sample-expressjs-aws-eks-ec2-asg-cdk
+        - ECR_REPO=sample-expressjs-app
         - AWS_REGION=us-west-1
         - STACK_TYPE=aws-eks-stack
       secrets:
@@ -33,9 +34,9 @@ pipelines:
           - git clone https://oauth2:$GITHUB_TOKEN@github.com/$ORG/$REPO
           - cd $REPO && ls -asl
           - git fetch && git checkout $REF
-          - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO
-          - docker build -f Dockerfile -t $AWS_ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO-$STACK_TYPE:$REF .
-          - docker push $AWS_ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO-$STACK_TYPE:$REF
+          - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO
+          - docker build -f Dockerfile -t $AWS_ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO-$STACK_TYPE:$REF .
+          - docker push $AWS_ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO-$STACK_TYPE:$REF
   - name: sample-expressjs-test-aws-eks-stack:0.2.0
     description: run tests
     env:
@@ -43,6 +44,7 @@ pipelines:
         - DEBIAN_FRONTEND=noninteractive
         - ORG=workflows-sh
         - REPO=sample-expressjs-aws-eks-ec2-asg-cdk
+        - ECR_REPO=sample-expressjs-app
       secrets:
         - GITHUB_TOKEN
     events:

--- a/ops.yml
+++ b/ops.yml
@@ -1,6 +1,6 @@
 version: "1"
 pipelines:
-  - name: sample-expressjs-pipeline-aws-eks-ec2-asg-cdk:0.1.3
+  - name: sample-expressjs-pipeline-aws-eks-stack:0.2.2
     description: build a release for deployment
     env:
       static:
@@ -8,7 +8,7 @@ pipelines:
         - ORG=workflows-sh
         - REPO=sample-expressjs-aws-eks-ec2-asg-cdk
         - AWS_REGION=us-west-1
-        - STACK_TYPE=aws-eks-ec2-asg-cdk
+        - STACK_TYPE=aws-eks-stack
       secrets:
         - GITHUB_TOKEN
         - AWS_ACCESS_KEY_ID
@@ -19,7 +19,7 @@ pipelines:
       - "github:workflows-sh/sample-expressjs-aws-eks-ec2-asg-cdk:pull_request.opened"
       - "github:workflows-sh/sample-expressjs-aws-eks-ec2-asg-cdk:pull_request.synchronize"
     jobs:
-      - name: sample-expressjs-build-job-aws-eks-ec2-asg-cdk
+      - name: sample-expressjs-build-job-aws-eks-stack
         description: sample-expressjs build step
         packages:
           - git
@@ -36,7 +36,7 @@ pipelines:
           - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO
           - docker build -f Dockerfile -t $AWS_ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO-$STACK_TYPE:$REF .
           - docker push $AWS_ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$REPO-$STACK_TYPE:$REF
-  - name: sample-expressjs-test-aws-eks-ec2-asg-cdk:0.1.4
+  - name: sample-expressjs-test-aws-eks-stack:0.2.0
     description: run tests
     env:
       static:
@@ -50,7 +50,7 @@ pipelines:
       - "github:workflows-sh/sample-expressjs-aws-eks-ec2-asg-cdk:pull_request.opened"
       - "github:workflows-sh/sample-expressjs-aws-eks-ec2-asg-cdk:pull_request.synchronize"
     jobs:
-      - name: sample-expressjs-test-job-aws-eks-ec2-asg-cdk
+      - name: sample-expressjs-test-job-aws-eks-stack
         description: sample-expressjs test step
         packages:
           - git
@@ -62,7 +62,7 @@ pipelines:
           - npm i
           - npm run test
 services:
-  - name: sample-expressjs-service-aws-eks-ec2-asg-cdk:0.1.5
+  - name: sample-expressjs-service-aws-eks-stack:0.2.0
     description: A sample expressjs service
     run: node /ops/index.js
     port: [ '8080:8080' ]

--- a/ops.yml
+++ b/ops.yml
@@ -1,6 +1,6 @@
 version: "1"
 pipelines:
-  - name: sample-expressjs-pipeline-aws-eks-stack:0.2.2
+  - name: sample-expressjs-pipeline-aws-eks-ec2-asg-cdk:0.1.3
     description: build a release for deployment
     env:
       static:
@@ -9,7 +9,7 @@ pipelines:
         - REPO=sample-expressjs-aws-eks-ec2-asg-cdk
         - ECR_REPO=sample-expressjs-app
         - AWS_REGION=us-west-1
-        - STACK_TYPE=aws-eks-stack
+        - STACK_TYPE=aws-eks-ec2-asg-cdk
       secrets:
         - GITHUB_TOKEN
         - AWS_ACCESS_KEY_ID
@@ -20,7 +20,7 @@ pipelines:
       - "github:workflows-sh/sample-expressjs-aws-eks-ec2-asg-cdk:pull_request.opened"
       - "github:workflows-sh/sample-expressjs-aws-eks-ec2-asg-cdk:pull_request.synchronize"
     jobs:
-      - name: sample-expressjs-build-job-aws-eks-stack
+      - name: sample-expressjs-build-job-aws-eks-ec2-asg-cdk
         description: sample-expressjs build step
         packages:
           - git
@@ -37,7 +37,7 @@ pipelines:
           - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO
           - docker build -f Dockerfile -t $AWS_ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO-$STACK_TYPE:$REF .
           - docker push $AWS_ACCOUNT_NUMBER.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO-$STACK_TYPE:$REF
-  - name: sample-expressjs-test-aws-eks-stack:0.2.0
+  - name: sample-expressjs-test-aws-eks-ec2-asg-cdk:0.1.4
     description: run tests
     env:
       static:
@@ -52,7 +52,7 @@ pipelines:
       - "github:workflows-sh/sample-expressjs-aws-eks-ec2-asg-cdk:pull_request.opened"
       - "github:workflows-sh/sample-expressjs-aws-eks-ec2-asg-cdk:pull_request.synchronize"
     jobs:
-      - name: sample-expressjs-test-job-aws-eks-stack
+      - name: sample-expressjs-test-job-aws-eks-ec2-asg-cdk
         description: sample-expressjs test step
         packages:
           - git
@@ -64,7 +64,7 @@ pipelines:
           - npm i
           - npm run test
 services:
-  - name: sample-expressjs-service-aws-eks-stack:0.2.0
+  - name: sample-expressjs-service-aws-eks-ec2-asg-cdk:0.1.5
     description: A sample expressjs service
     run: node /ops/index.js
     port: [ '8080:8080' ]


### PR DESCRIPTION
The workflow names (and corresponding `STACK_TYPE` environment variables) that list out all of the resources deployed in the stack makes for resources that are difficult to parse at a glance. To improve the typeability of the workflow names and the readability of the produced resource names, I've simplified the names of the workflows down to `sample-expressjs-*-aws-eks-stack`.

This goes with the corresponding PR for the stack itself, https://github.com/workflows-sh/aws-eks-ec2-asg-cdk/pull/32

This PR also creates a new `ECR_REPO` static variable for the workflows that is used to define the short name for the stack when the ECR repo is being created, rather than the longer name of the GitHub repo (while still allowing the container to put the GH repo)